### PR TITLE
Improving the get method return annotation.

### DIFF
--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -76,7 +76,9 @@ class ServiceContainer implements ContainerInterface
      *
      * @param class-string<T> $id Identifier of the entry to look for.
      *
-     * @return T|ServiceContainer
+     * @return T
+     *
+     * @phpstan-return (T is static ? static : T)
      *
      * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
      * @throws ContainerExceptionInterface Error while retrieving the entry.


### PR DESCRIPTION
The current return annotation of the `ServiceContainer::get` method `@return T|ServiceContainer` is unnecessarily generic - even when a static analyzer (PHPStan, Psalm) is able to recognize the type `T`, the `ServiceContainer` type is forced into the result.

Ideally `@return T` would be enough (it already includes the `T = ServiceContainer` case) but it looks like there's an issue in PHPStan that it doesn't see `ServiceContainer` as a subtype of `T` in this case. I've reported the issue at https://github.com/phpstan/phpstan/issues/8756.

Until the PHPStan issue is solved, we can use a workaround that utilizes the conditional type declaration (as demonstrated here: https://phpstan.org/r/f2c3eb91-c6b0-45ca-9dd5-d434274f82af).

There's no such issue with Psalm (as shown here: https://psalm.dev/r/85f8d8262c) so I think we should only introduce the workaround with a PHPStan-specific annotation (`@phpstan-return`).

Also note that Intelephense doesn't recognize templates, so `@return T` won't work well with it too. However, neither did `@return T|ServiceContainer`. So if we wanted to make it work well even with Intelephense, we should probaly use `@return mixed`, `@psalm-return T` and `@phpstan-return (T is static ? static : T)`.